### PR TITLE
Use proper dependency on executable

### DIFF
--- a/doctest-driver-gen.cabal
+++ b/doctest-driver-gen.cabal
@@ -38,7 +38,7 @@ test-suite doctest-driver-gen-test
   main-is:             doctest-driver.hs
   build-depends:       base
                      , doctest
-                     , doctest-driver-gen
+  build-tool-depends:  doctest-driver-gen:doctest-driver-gen
   ghc-options:         -threaded -rtsopts -with-rtsopts=-N
   default-language:    Haskell2010
 


### PR DESCRIPTION
This restores tests with Stack with no builds being run before them and also fixes tests with `cabal new-test`