### PR TITLE
Allow base-4.17.0.0 (GHC 9.4)

### DIFF
--- a/doctest-driver-gen.cabal
+++ b/doctest-driver-gen.cabal
@@ -35,7 +35,7 @@ tested-with:
 library
   hs-source-dirs:      src
   exposed-modules:     Test.DocTest.Gen
-  build-depends:       base >= 4.0 && < 4.17
+  build-depends:       base >= 4.0 && < 4.18
                        -- Versions of doctest available in this library
                        -- , doctest >= 0.7 && < 0.12 || >= 0.13 && < 0.21
   ghc-options:         -Wall


### PR DESCRIPTION
I tested this with:

```
$ cabal --version
cabal-install version 3.8.1.0
compiled using version 3.8.1.0 of the Cabal library
$ ghc --version
The Glorious Glasgow Haskell Compilation System, version 9.4.2
$ for action in build test ; do cabal $action --enable-tests || break ; done
# this built the library and ran the tests, which passed
```